### PR TITLE
added binary flag to read shapefiles in windows

### DIFF
--- a/src/gsimporter/client.py
+++ b/src/gsimporter/client.py
@@ -233,7 +233,7 @@ class _Client(object):
             key = fpair[0]
             if len(fpair) == 2:
                 filename = os.path.basename(fpair[1])
-                fp = open(fpair[1])
+                fp = open(fpair[1], 'rb')
                 value = fp.read()
                 fp.close()
             else:


### PR DESCRIPTION
Shapefiles were not being written to the geoserver temp directory on upload, crashing the rest of the import process.
