### PR TITLE
fixes ascii error for tif imports

### DIFF
--- a/src/gsimporter/client.py
+++ b/src/gsimporter/client.py
@@ -240,7 +240,7 @@ class _Client(object):
                 filename, value = fpair[1:]
             L.append('--' + BOUNDARY)
             L.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (str(key), str(filename)))
-            L.append('Content-Type: %s' % _get_content_type(filename))
+            L.append('Content-Type: %s' % str(_get_content_type(filename)))
             L.append('')
             L.append(value)
         L.append('--' + BOUNDARY + '--')


### PR DESCRIPTION
Windows users are getting ascii decoding error as mentioned in the GeoNode forum (https://groups.google.com/forum/#!topic/geonode-users/TvFIjqurUfg) when attempting to upload geotiffs.  The _get_content_type function returns a unicode, which fails to concatenate with strings in the CRLF.join(L) line.  Wrapping the function in the str function will typecast it appropriately.  